### PR TITLE
chore: rename org from Wuji-Technology-Co-Ltd to wuji-technology

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This package provides the URDF model, MuJoCo (MJCF) models, and meshes for the W
 If you only want to view the model in MuJoCo, you don't need to build the ROS package. Just ensure you have the `mujoco` python package installed.
 
 ```
-git clone https://github.com/Wuji-Technology-Co-Ltd/wuji_hand_description.git
+git clone https://github.com/wuji-technology/wuji_hand_description.git
 
 pip install mujoco
 ```
@@ -44,7 +44,7 @@ Navigate to the `src` directory of your ROS 2 workspace(for example, `~/ros2_ws/
 
 ```
 cd ~/ros2_ws/src
-git clone https://github.com/Wuji-Technology-Co-Ltd/wuji_hand_description.git
+git clone https://github.com/wuji-technology/wuji_hand_description.git
 ```
 
 ### 2.2 Install Dependencies

--- a/package.xml
+++ b/package.xml
@@ -10,8 +10,8 @@
   <license>MIT</license>
     
   <url type="website">wuji.tech</url>
-  <url type="bugtracker">https://github.com/Wuji-Technology-Co-Ltd/wujihand-urdf/issues</url>
-  <url type="repository">https://github.com/Wuji-Technology-Co-Ltd/wujihand-urdf</url>
+  <url type="bugtracker">https://github.com/wuji-technology/wujihand-urdf/issues</url>
+  <url type="repository">https://github.com/wuji-technology/wujihand-urdf</url>
   
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>


### PR DESCRIPTION
将所有 GitHub 组织名引用从 `Wuji-Technology-Co-Ltd` 更新为 `wuji-technology`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **文档**
  * 已更新文档中的GitHub组织引用。

* **杂项**
  * 已更新包元数据中的bug追踪器和代码仓库链接。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->