### PR TITLE
docs: add release badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # wuji-hand-description
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/wuji-technology/wuji-hand-description)](https://github.com/wuji-technology/wuji-hand-description/releases)
 
 Robot model description package for Wuji Hand. Provides URDF models, MuJoCo (MJCF) models, and high-quality meshes for simulation and visualization. Includes configuration files for ROS2 visualization (RViz).
 


### PR DESCRIPTION
## Summary
- Add Release badge to README.md after License badge
- Badge shows current release version (v0.2.0) from shields.io
- Badge links to releases page for easy access

## Test plan
- [ ] Verify badge displays correctly in GitHub README
- [ ] Click badge to confirm it links to releases page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 在README中添加了Release badge标识

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->