### PR TITLE
ci: add auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,159 @@
+name: Auto Release from CHANGELOG
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse CHANGELOG and Upsert Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            // 检查 CHANGELOG.md 是否存在
+            if (!fs.existsSync('CHANGELOG.md')) {
+              core.setFailed('CHANGELOG.md not found');
+              return;
+            }
+            const changelog = fs.readFileSync('CHANGELOG.md', 'utf8')
+              .replace(/\r\n?/g, '\n');
+
+            // 从 tag 提取版本号（支持预发布版本如 1.0.0-rc4）
+            const tag = context.ref.replace('refs/tags/', '');
+            const version = tag.replace(/^v/, '');
+            console.log(`Processing tag: ${tag}, version: ${version}`);
+
+            // 分类映射
+            const categoryMap = {
+              'Added': 'New Features', '新增': 'New Features',
+              'Changed': 'Improvements', '变更': 'Improvements',
+              'Fixed': 'Bug Fixes', '修复': 'Bug Fixes'
+            };
+            const cautionCategories = {
+              'Removed': 'Removed', '移除': 'Removed',
+              'Deprecated': 'Deprecated', '废弃': 'Deprecated',
+              'Security': 'Security', '安全': 'Security'
+            };
+
+            // 解析版本内容
+            function parseContent(content) {
+              const sections = { 'New Features': [], 'Improvements': [], 'Bug Fixes': [] };
+              const cautionItems = [];
+              let currentCategory = '';
+              let currentCautionPrefix = '';
+
+              for (const line of content.trim().split('\n')) {
+                const catMatch = line.match(/^### (.+)/);
+                if (catMatch) {
+                  const cat = catMatch[1].trim();
+                  if (categoryMap[cat]) {
+                    currentCategory = categoryMap[cat];
+                    currentCautionPrefix = '';
+                  } else if (cautionCategories[cat]) {
+                    currentCategory = 'CAUTION';
+                    currentCautionPrefix = cautionCategories[cat];
+                  } else {
+                    currentCategory = '';
+                  }
+                } else if (line.startsWith('- ')) {
+                  const item = line.slice(2);
+                  if (currentCategory === 'CAUTION') {
+                    cautionItems.push(`**${currentCautionPrefix}**: ${item}`);
+                  } else if (currentCategory && sections[currentCategory]) {
+                    sections[currentCategory].push(item);
+                  }
+                }
+              }
+
+              let body = '';
+              for (const section of ['New Features', 'Improvements', 'Bug Fixes']) {
+                if (sections[section].length > 0) {
+                  body += `### ${section}\n${sections[section].map(i => `- ${i}`).join('\n')}\n\n`;
+                }
+              }
+              if (cautionItems.length > 0) {
+                body += `> [!CAUTION]\n${cautionItems.map(i => `> - ${i}`).join('\n')}\n\n`;
+              }
+              return body.trim();
+            }
+
+            // 转义版本号中的特殊字符用于正则匹配
+            const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+            // 版本匹配正则（支持多种日期格式）
+            const versionRegex = new RegExp(`## \\[${escapedVersion}\\](?:[^\\n]*-\\s*(\\d{4}-\\d{2}-\\d{2}))?[^\\n]*\\n([\\s\\S]*?)(?=\\n## \\[|$)`);
+            const match = changelog.match(versionRegex);
+
+            if (!match) {
+              core.setFailed(`Version ${version} not found in CHANGELOG.md`);
+              return;
+            }
+
+            const date = match[1] || new Date().toISOString().split('T')[0];
+            const content = match[2];
+            let body = parseContent(content);
+
+            if (!body) {
+              console.log(`Warning: No content parsed for version ${version}`);
+            }
+
+            // 获取所有版本用于 Full Changelog（支持预发布版本）
+            const allVersions = [...changelog.matchAll(/## \[(\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)\]/g)].map(m => m[1]);
+            const versionIndex = allVersions.indexOf(version);
+            if (versionIndex === -1) {
+              console.log(`Warning: version ${version} not found in version list for Full Changelog`);
+            } else {
+              const prevVersion = allVersions[versionIndex + 1];
+              if (prevVersion) {
+                body += `\n\n---\n\n**Full Changelog**: [v${prevVersion}...${tag}](https://github.com/${context.repo.owner}/${context.repo.repo}/compare/v${prevVersion}...${tag})`;
+              }
+            }
+
+            // 检查 release 是否已存在（upsert 模式）
+            let releaseId = null;
+            try {
+              const { data } = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag
+              });
+              releaseId = data.id;
+              console.log(`Found existing release: ${tag} (id: ${releaseId})`);
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              console.log(`No existing release for tag: ${tag}`);
+            }
+
+            const releaseBody = `## ${tag} (${date})\n\n${body}`;
+            const releaseData = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: tag,
+              body: releaseBody,
+              prerelease: true,
+              make_latest: 'false'
+            };
+
+            if (releaseId) {
+              await github.rest.repos.updateRelease({
+                ...releaseData,
+                release_id: releaseId
+              });
+              console.log(`Updated release: ${tag}`);
+            } else {
+              await github.rest.repos.createRelease(releaseData);
+              console.log(`Created pre-release: ${tag}`);
+            }


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically create releases from CHANGELOG.md
- Triggered on tag push (v*)
- Supports Chinese/English CHANGELOG categories
- Includes upsert mode, CRLF compatibility, version escaping, and pre-release version support

## Test plan
- [ ] Merge PR and create a tag to verify release is created
- [ ] Verify release notes formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 启用自动发布工作流程，在推送版本标签时自动创建发布
  * 发布说明从项目变更日志自动生成，自动分类新功能、改进和问题修复
  * 支持预发布版本的自动处理
  * 发布链接自动关联到前一个版本

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->