### PR TITLE
chore(docs): fix CHANGELOG format and mesh path description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix mesh file paths in URDF files (use relative path `../meshes/right/` or `../meshes/left/` respectively instead of filename only)
 
-## [0.2.1] - 2026-01-30
+## [0.2.1] - 2026-01-20
 
 ### Fixed
 
@@ -20,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix joint torque limits
 - Fix self-collision groups
 - Fix RViz fixed frame for right hand visualization
-- Fix mesh file paths in URDF files (use relative path `../meshes/` instead of filename only)
 
 ## [0.2.0] - 2026-01-19
 


### PR DESCRIPTION
## Summary

- Align CHANGELOG with current release state
- Move unreleased content (mesh file paths fix) to `[Unreleased]` section
- Fix v0.2.1 release date to `2026-01-20` (matching actual release)

Resolve m-6735303503

## Test plan

验证步骤：
1. 确认 v0.2.1 内容与 GitHub Release 一致
2. 确认未发布的变更在 `[Unreleased]` 中
3. 确认日期与实际发布日期匹配

结果：
✅ CHANGELOG 与 release 状态一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)