### PR TITLE
ci: add auto-release-on-pr workflow

### DIFF
--- a/.github/workflows/auto-release-on-pr.yml
+++ b/.github/workflows/auto-release-on-pr.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          fetch-tags: true
 
       - name: Extract version and create tag
         env:
@@ -38,7 +39,7 @@ jobs:
             exit 1
           fi
 
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
             echo "::error::Tag $VERSION already exists"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Add `auto-release-on-pr.yml` workflow that creates a git tag when a PR with `auto-release` label is merged from a `release/v*` branch
- Part of centralized release automation deployment

## Test plan

- Verify workflow file syntax is correct
- End-to-end test will be done via centralized-release.yml trigger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores（杂项）**
  * 新增自动化发布工作流程。在PR被标记为自动发布且分支名称符合版本命名规范时，自动生成版本标签并推送到仓库。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->