### PR TITLE
docs: add Docs Center link and switch to Quick Start template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,7 @@
 
 Robot model description package for Wuji Hand. Provides URDF, MuJoCo (MJCF), and USD assets for simulation and visualization. Includes ROS2 launch and RViz configuration files for quick inspection of left and right hand models.
 
-## Table of Contents
-
-- [Repository Structure](#repository-structure)
-- [Usage](#usage)
-  - [Prerequisites](#prerequisites)
-  - [Installation](#installation)
-  - [Running](#running)
-  - [Output](#output)
-- [Contact](#contact)
+**Get started with [Quick Start](#quick-start). For detailed documentation, refer to [Wuji Hand Description Guide](https://docs.wuji.tech/docs/en/wuji-hand/latest/wuji-hand-description-guide/) on Wuji Docs Center.**
 
 ## Repository Structure
 
@@ -29,31 +21,12 @@ Robot model description package for Wuji Hand. Provides URDF, MuJoCo (MJCF), and
 └── README.md
 ```
 
-## Usage
-
-### Prerequisites
-
-- Python 3 and the `mujoco` package for MuJoCo viewing
-- ROS2 Humble or Rolling for RViz visualization
-- NVIDIA Isaac Sim for USD asset inspection
+## Quick Start
 
 ### Installation
 
 ```bash
 git clone https://github.com/wuji-technology/wuji-hand-description.git
-cd wuji-hand-description
-pip install mujoco
-```
-
-For ROS2 workspace usage:
-
-```bash
-cd ~/ros2_ws/src
-git clone https://github.com/wuji-technology/wuji-hand-description.git
-cd ..
-rosdep install --from-paths src --ignore-src -r -y
-colcon build --packages-select wuji_hand_description
-source install/setup.bash
 ```
 
 ### Running
@@ -61,15 +34,29 @@ source install/setup.bash
 #### MuJoCo
 
 ```bash
+# Navigate to the repository directory
+cd wuji-hand-description
+
+# Right hand
 python -m mujoco.viewer --mjcf=mjcf/right.xml
+
+# Left hand
 python -m mujoco.viewer --mjcf=mjcf/left.xml
 ```
 
 #### ROS2 and RViz
 
 ```bash
+# Source ROS2 environment, replace <distro> with your installed ROS2 distribution
+source /opt/ros/<distro>/setup.bash
+
+cd ~/ros2_ws/src
+git clone https://github.com/wuji-technology/wuji-hand-description.git
+cd ..
+rosdep install --from-paths src --ignore-src -r -y
+colcon build --packages-select wuji_hand_description
+source install/setup.bash
 ros2 launch wuji_hand_description display.launch.py
-ros2 launch wuji_hand_description display.launch.py hand:=right
 ```
 
 #### Isaac Sim (USD)
@@ -77,14 +64,6 @@ ros2 launch wuji_hand_description display.launch.py hand:=right
 Load `usd/left/wujihand.usd` or `usd/right/wujihand.usd` directly in Isaac Sim.
 For a complete simulation example, see [isaaclab-sim](https://github.com/wuji-technology/isaaclab-sim).
 
-### Output
-
-```text
-- MuJoCo loads the left or right hand model for interactive inspection.
-- ROS2 launches robot_state_publisher, joint_state_publisher_gui, and RViz.
-- Isaac Sim opens the prebuilt USD asset with materials, physics, and collision filters.
-```
-
 ## Contact
 
-For any questions, please contact support@wuji.tech.
+For any questions, please contact [support@wuji.tech](mailto:support@wuji.tech).

--- a/README.md
+++ b/README.md
@@ -50,13 +50,20 @@ python -m mujoco.viewer --mjcf=mjcf/left.xml
 # Source ROS2 environment, replace <distro> with your installed ROS2 distribution
 source /opt/ros/<distro>/setup.bash
 
+# If not cloned in this workspace yet:
 cd ~/ros2_ws/src
 git clone https://github.com/wuji-technology/wuji-hand-description.git
 cd ..
+
 rosdep install --from-paths src --ignore-src -r -y
 colcon build --packages-select wuji_hand_description
 source install/setup.bash
+
+# Left hand (default)
 ros2 launch wuji_hand_description display.launch.py
+
+# Right hand
+ros2 launch wuji_hand_description display.launch.py hand:=right
 ```
 
 #### Isaac Sim (USD)


### PR DESCRIPTION
## Summary

- Add Docs Center link for Wuji Hand Description Guide
- Replace Usage with Quick Start template (repo is on Docs Center)
- Remove Table of Contents (not required for Docs Center repos)
- Align commands with Docs Center formatting (MuJoCo cd step, ROS2 source step)
- Use mailto link format in Contact section

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify Docs Center link resolves to the correct page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 重构 README：移除页内目录与原“Usage”部分，新增顶级“快速开始”并链接至外部详细手册
  * 合并并简化 MuJoCo 与 ROS2/RViz 的安装与运行说明，突出在“快速开始 → Running → ROS2 and RViz”中执行的步骤
  * 明确 MuJoCo 启动需先切换目录并保留左右手查看示例；ROS2 指令添加了环境 sourcing 与在工作区克隆/导航的条件说明
  * 删除原“Output”内容；联系方式改为可点击邮件链接
<!-- end of auto-generated comment: release notes by coderabbit.ai -->