### PR TITLE
feat: add fingertip sites and unify URDF joint limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added named `<site>` elements at all ten fingertips in `mjcf/left.xml` and `mjcf/right.xml` (`left_finger1_tip` ~ `left_finger5_tip`, `right_finger1_tip` ~ `right_finger5_tip`) for inverse kinematics targets, fingertip pose queries, and touch sensor attachment. Sites are placed in `group="3"` and hidden by default.
+- Added a Fingertip sites section to the README with a Python `mujoco` snippet showing how to resolve a site by name and read its world-frame pose.
+
+### Fixed
+
+- Unified left/right hand joint `<limit>` lower/upper bounds across `urdf/left.urdf`, `urdf/right.urdf`, `urdf/left-ros.urdf`, and `urdf/right-ros.urdf` by taking the averaged calibrated values, eliminating residual left/right asymmetry left over from the sysid calibration output.
+- Restored the four non-thumb MCP2 joints to the standard `-0.37` / `0.37` range in the same URDF files after the calibration pipeline had widened them slightly, keeping behavior consistent with `v0.2.4`.
+
 ## [0.2.5] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,6 +72,31 @@ ros2 launch wuji_hand_description display.launch.py hand:=right
 Load `usd/left/wujihand.usd` or `usd/right/wujihand.usd` directly in Isaac Sim.
 For a complete simulation example, see [isaaclab-sim](https://github.com/wuji-technology/isaaclab-sim).
 
+#### Fingertip sites (MJCF)
+
+`mjcf/left.xml` and `mjcf/right.xml` expose ten named `<site>` elements — one per
+fingertip — for inverse kinematics targets, fingertip pose queries, and touch
+sensor attachment. Names follow the pattern `{left,right}_finger{1..5}_tip`
+(for example `left_finger1_tip`, `right_finger5_tip`).
+
+Sites belong to `group="3"` and are hidden by default. In `mujoco.viewer`,
+open the control panel (Tab) and enable site rendering, then toggle Group 3
+under Rendering to see them.
+
+Read a site pose from Python:
+
+```python
+import mujoco
+
+model = mujoco.MjModel.from_xml_path("mjcf/left.xml")
+data = mujoco.MjData(model)
+mujoco.mj_forward(model, data)
+
+site_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "left_finger1_tip")
+tip_pos = data.site_xpos[site_id]            # (3,) world-frame position
+tip_mat = data.site_xmat[site_id].reshape(3, 3)  # rotation matrix
+```
+
 #### Docking module
 
 The `docking/` directory ships a standalone docking link (URDF, MJCF, USD, STL)

--- a/mjcf/left.xml
+++ b/mjcf/left.xml
@@ -55,6 +55,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger1_link4" contype="1" conaffinity="1" />
             <geom pos="-0.00105 0.0002 0.0273" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="left_finger1_tip_link" />
             <geom pos="-0.00105 0.0002 0.0273" type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger1_tip_link" contype="1" conaffinity="1" />
+            <site name="left_finger1_tip" pos="-0.00105 0.0002 0.0313" group="3" />
           </body>
         </body>
       </body>
@@ -81,6 +82,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger2_link4" contype="1" conaffinity="1" />
             <geom pos="-0.0010521 0.000210869 0.0267" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="left_finger2_tip_link" />
             <geom pos="-0.0010521 0.000210869 0.0267" type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger2_tip_link" contype="1" conaffinity="1" />
+            <site name="left_finger2_tip" pos="-0.0010521 0.000210869 0.0267" group="3" />
           </body>
         </body>
       </body>
@@ -107,6 +109,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger3_link4" contype="1" conaffinity="1" />
             <geom pos="-0.0010504 0.000202672 0.0267" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="left_finger3_tip_link" />
             <geom pos="-0.0010504 0.000202672 0.0267" type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger3_tip_link" contype="1" conaffinity="1" />
+            <site name="left_finger3_tip" pos="-0.0010504 0.000202672 0.0267" group="3" />
           </body>
         </body>
       </body>
@@ -133,6 +136,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger4_link4" contype="1" conaffinity="1" />
             <geom pos="-0.00104998 0.000202557 0.0267" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="left_finger4_tip_link" />
             <geom pos="-0.00104998 0.000202557 0.0267" type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger4_tip_link" contype="1" conaffinity="1" />
+            <site name="left_finger4_tip" pos="-0.00104998 0.000202557 0.0267" group="3" />
           </body>
         </body>
       </body>
@@ -159,6 +163,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger5_link4" contype="1" conaffinity="1" />
             <geom pos="-0.00105041 0.000201047 0.0267" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="left_finger5_tip_link" />
             <geom pos="-0.00105041 0.000201047 0.0267" type="mesh" rgba="0.6 0.8 0.9 1" mesh="left_finger5_tip_link" contype="1" conaffinity="1" />
+            <site name="left_finger5_tip" pos="-0.00105041 0.000201047 0.0267" group="3" />
           </body>
         </body>
       </body>

--- a/mjcf/right.xml
+++ b/mjcf/right.xml
@@ -55,6 +55,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger1_link4" contype="1" conaffinity="1" />
             <geom pos="-0.00105 -0.0002 0.0273" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="right_finger1_tip_link" />
             <geom pos="-0.00105 -0.0002 0.0273" type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger1_tip_link" contype="1" conaffinity="1" />
+            <site name="right_finger1_tip" pos="-0.00105 -0.0002 0.0313" group="3" />
           </body>
         </body>
       </body>
@@ -81,6 +82,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger2_link4" contype="1" conaffinity="1" />
             <geom pos="-0.00105 0.0002 0.0267" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="right_finger2_tip_link" />
             <geom pos="-0.00105 0.0002 0.0267" type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger2_tip_link" contype="1" conaffinity="1" />
+            <site name="right_finger2_tip" pos="-0.00105 0.0002 0.0267" group="3" />
           </body>
         </body>
       </body>
@@ -107,6 +109,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger3_link4" contype="1" conaffinity="1" />
             <geom pos="-0.00104909 0.00020104 0.0267" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="right_finger3_tip_link" />
             <geom pos="-0.00104909 0.00020104 0.0267" type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger3_tip_link" contype="1" conaffinity="1" />
+            <site name="right_finger3_tip" pos="-0.00104909 0.00020104 0.0267" group="3" />
           </body>
         </body>
       </body>
@@ -133,6 +136,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger4_link4" contype="1" conaffinity="1" />
             <geom pos="-0.00105961 0.000190451 0.0267" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="right_finger4_tip_link" />
             <geom pos="-0.00105961 0.000190451 0.0267" type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger4_tip_link" contype="1" conaffinity="1" />
+            <site name="right_finger4_tip" pos="-0.00105961 0.000190451 0.0267" group="3" />
           </body>
         </body>
       </body>
@@ -159,6 +163,7 @@
             <geom type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger5_link4" contype="1" conaffinity="1" />
             <geom pos="-0.00104464 0.00021131 0.0267" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.6 0.8 0.9 1" mesh="right_finger5_tip_link" />
             <geom pos="-0.00104464 0.00021131 0.0267" type="mesh" rgba="0.6 0.8 0.9 1" mesh="right_finger5_tip_link" contype="1" conaffinity="1" />
+            <site name="right_finger5_tip" pos="-0.00104464 0.00021131 0.0267" group="3" />
           </body>
         </body>
       </body>

--- a/urdf/left-ros.urdf
+++ b/urdf/left-ros.urdf
@@ -71,8 +71,8 @@
     <axis
       xyz="0 -1 0" />
     <limit
-      lower="0.0583"
-      upper="1.5941"
+      lower="0.0475"
+      upper="1.6033"
       effort="0.4452"
       velocity="8.587" />
   </joint>
@@ -116,8 +116,8 @@
     <axis
       xyz="0 0.999999999999998 0" />
     <limit
-      lower="-0.1199"
-      upper="0.9335"
+      lower="-0.1387"
+      upper="0.9324"
       effort="0.4259"
       velocity="11.1" />
   </joint>
@@ -161,8 +161,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4646"
-      upper="1.5639"
+      lower="-0.4642"
+      upper="1.5623"
       effort="0.1888"
       velocity="12.863" />
   </joint>
@@ -206,8 +206,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4570"
-      upper="1.5684"
+      lower="-0.4699"
+      upper="1.5568"
       effort="0.1468"
       velocity="13.578" />
   </joint>
@@ -291,8 +291,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1560"
-      upper="1.5619"
+      lower="-0.1585"
+      upper="1.5604"
       effort="0.6188"
       velocity="8.203" />
   </joint>
@@ -336,8 +336,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4095"
-      upper="0.2921"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1822"
       velocity="8.115" />
   </joint>
@@ -381,8 +381,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4839"
-      upper="1.5466"
+      lower="-0.4777"
+      upper="1.5485"
       effort="0.2251"
       velocity="12.863" />
   </joint>
@@ -426,8 +426,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4723"
-      upper="1.5754"
+      lower="-0.4683"
+      upper="1.5753"
       effort="0.2170"
       velocity="13.578" />
   </joint>
@@ -511,8 +511,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1569"
-      upper="1.5536"
+      lower="-0.1644"
+      upper="1.5516"
       effort="0.6494"
       velocity="8.203" />
   </joint>
@@ -556,8 +556,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.3977"
-      upper="0.3115"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1827"
       velocity="8.115" />
   </joint>
@@ -601,8 +601,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4847"
-      upper="1.5411"
+      lower="-0.4739"
+      upper="1.5512"
       effort="0.2078"
       velocity="12.863" />
   </joint>
@@ -646,8 +646,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4671"
-      upper="1.5788"
+      lower="-0.4684"
+      upper="1.5745"
       effort="0.2018"
       velocity="13.578" />
   </joint>
@@ -731,8 +731,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1507"
-      upper="1.5636"
+      lower="-0.1554"
+      upper="1.5585"
       effort="0.6389"
       velocity="8.203" />
   </joint>
@@ -776,8 +776,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4101"
-      upper="0.3014"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1832"
       velocity="8.115" />
   </joint>
@@ -821,8 +821,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4747"
-      upper="1.5526"
+      lower="-0.4765"
+      upper="1.5487"
       effort="0.2249"
       velocity="12.863" />
   </joint>
@@ -866,8 +866,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4729"
-      upper="1.5718"
+      lower="-0.4777"
+      upper="1.5634"
       effort="0.2044"
       velocity="13.578" />
   </joint>
@@ -951,8 +951,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1578"
-      upper="1.5632"
+      lower="-0.1626"
+      upper="1.5585"
       effort="0.6441"
       velocity="8.203" />
   </joint>
@@ -996,8 +996,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4103"
-      upper="0.2949"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1798"
       velocity="8.115" />
   </joint>
@@ -1041,8 +1041,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4733"
-      upper="1.5560"
+      lower="-0.4768"
+      upper="1.5490"
       effort="0.2384"
       velocity="12.863" />
   </joint>
@@ -1086,8 +1086,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4662"
-      upper="1.5760"
+      lower="-0.4683"
+      upper="1.5735"
       effort="0.1866"
       velocity="13.578" />
   </joint>

--- a/urdf/left.urdf
+++ b/urdf/left.urdf
@@ -71,8 +71,8 @@
     <axis
       xyz="0 -1 0" />
     <limit
-      lower="0.0583"
-      upper="1.5941"
+      lower="0.0475"
+      upper="1.6033"
       effort="0.4452"
       velocity="8.587" />
   </joint>
@@ -116,8 +116,8 @@
     <axis
       xyz="0 0.999999999999998 0" />
     <limit
-      lower="-0.1199"
-      upper="0.9335"
+      lower="-0.1387"
+      upper="0.9324"
       effort="0.4259"
       velocity="11.1" />
   </joint>
@@ -161,8 +161,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4646"
-      upper="1.5639"
+      lower="-0.4642"
+      upper="1.5623"
       effort="0.1888"
       velocity="12.863" />
   </joint>
@@ -206,8 +206,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4570"
-      upper="1.5684"
+      lower="-0.4699"
+      upper="1.5568"
       effort="0.1468"
       velocity="13.578" />
   </joint>
@@ -291,8 +291,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1560"
-      upper="1.5619"
+      lower="-0.1585"
+      upper="1.5604"
       effort="0.6188"
       velocity="8.203" />
   </joint>
@@ -336,8 +336,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4095"
-      upper="0.2921"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1822"
       velocity="8.115" />
   </joint>
@@ -381,8 +381,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4839"
-      upper="1.5466"
+      lower="-0.4777"
+      upper="1.5485"
       effort="0.2251"
       velocity="12.863" />
   </joint>
@@ -426,8 +426,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4723"
-      upper="1.5754"
+      lower="-0.4683"
+      upper="1.5753"
       effort="0.2170"
       velocity="13.578" />
   </joint>
@@ -511,8 +511,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1569"
-      upper="1.5536"
+      lower="-0.1644"
+      upper="1.5516"
       effort="0.6494"
       velocity="8.203" />
   </joint>
@@ -556,8 +556,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.3977"
-      upper="0.3115"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1827"
       velocity="8.115" />
   </joint>
@@ -601,8 +601,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4847"
-      upper="1.5411"
+      lower="-0.4739"
+      upper="1.5512"
       effort="0.2078"
       velocity="12.863" />
   </joint>
@@ -646,8 +646,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4671"
-      upper="1.5788"
+      lower="-0.4684"
+      upper="1.5745"
       effort="0.2018"
       velocity="13.578" />
   </joint>
@@ -731,8 +731,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1507"
-      upper="1.5636"
+      lower="-0.1554"
+      upper="1.5585"
       effort="0.6389"
       velocity="8.203" />
   </joint>
@@ -776,8 +776,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4101"
-      upper="0.3014"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1832"
       velocity="8.115" />
   </joint>
@@ -821,8 +821,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4747"
-      upper="1.5526"
+      lower="-0.4765"
+      upper="1.5487"
       effort="0.2249"
       velocity="12.863" />
   </joint>
@@ -866,8 +866,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4729"
-      upper="1.5718"
+      lower="-0.4777"
+      upper="1.5634"
       effort="0.2044"
       velocity="13.578" />
   </joint>
@@ -951,8 +951,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1578"
-      upper="1.5632"
+      lower="-0.1626"
+      upper="1.5585"
       effort="0.6441"
       velocity="8.203" />
   </joint>
@@ -996,8 +996,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4103"
-      upper="0.2949"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1798"
       velocity="8.115" />
   </joint>
@@ -1041,8 +1041,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4733"
-      upper="1.5560"
+      lower="-0.4768"
+      upper="1.5490"
       effort="0.2384"
       velocity="12.863" />
   </joint>
@@ -1086,8 +1086,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4662"
-      upper="1.5760"
+      lower="-0.4683"
+      upper="1.5735"
       effort="0.1866"
       velocity="13.578" />
   </joint>

--- a/urdf/right-ros.urdf
+++ b/urdf/right-ros.urdf
@@ -71,8 +71,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="0.0368"
-      upper="1.6125"
+      lower="0.0475"
+      upper="1.6033"
       effort="0.4452"
       velocity="8.587" />
   </joint>
@@ -116,8 +116,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1576"
-      upper="0.9312"
+      lower="-0.1387"
+      upper="0.9324"
       effort="0.4259"
       velocity="11.1" />
   </joint>
@@ -161,8 +161,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4638"
-      upper="1.5607"
+      lower="-0.4642"
+      upper="1.5623"
       effort="0.1888"
       velocity="12.863" />
   </joint>
@@ -206,8 +206,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4829"
-      upper="1.5451"
+      lower="-0.4699"
+      upper="1.5568"
       effort="0.1468"
       velocity="13.578" />
   </joint>
@@ -291,8 +291,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1611"
-      upper="1.5588"
+      lower="-0.1585"
+      upper="1.5604"
       effort="0.6188"
       velocity="8.203" />
   </joint>
@@ -336,8 +336,8 @@
     <axis
       xyz="0 0.999999999978991 0" />
     <limit
-      lower="-0.4044"
-      upper="0.3054"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1822"
       velocity="8.1158" />
   </joint>
@@ -381,8 +381,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4714"
-      upper="1.5504"
+      lower="-0.4777"
+      upper="1.5485"
       effort="0.2251"
       velocity="12.863" />
   </joint>
@@ -426,7 +426,7 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4644"
+      lower="-0.4683"
       upper="1.5753"
       effort="0.2170"
       velocity="13.578" />
@@ -511,8 +511,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1719"
-      upper="1.5496"
+      lower="-0.1644"
+      upper="1.5516"
       effort="0.6494"
       velocity="8.203" />
   </joint>
@@ -556,8 +556,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4014"
-      upper="0.2996"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1827"
       velocity="8.1158" />
   </joint>
@@ -601,8 +601,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4632"
-      upper="1.5613"
+      lower="-0.4739"
+      upper="1.5512"
       effort="0.2078"
       velocity="12.863" />
   </joint>
@@ -646,8 +646,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4697"
-      upper="1.5702"
+      lower="-0.4684"
+      upper="1.5745"
       effort="0.2018"
       velocity="13.579" />
   </joint>
@@ -731,8 +731,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1601"
-      upper="1.5534"
+      lower="-0.1554"
+      upper="1.5585"
       effort="0.6389"
       velocity="8.203" />
   </joint>
@@ -776,8 +776,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4134"
-      upper="0.3161"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1832"
       velocity="8.1158" />
   </joint>
@@ -821,8 +821,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4782"
-      upper="1.5448"
+      lower="-0.4765"
+      upper="1.5487"
       effort="0.2249"
       velocity="12.863" />
   </joint>
@@ -866,8 +866,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4825"
-      upper="1.5550"
+      lower="-0.4777"
+      upper="1.5634"
       effort="0.2044"
       velocity="13.579" />
   </joint>
@@ -951,8 +951,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1674"
-      upper="1.5539"
+      lower="-0.1626"
+      upper="1.5585"
       effort="0.6441"
       velocity="8.203" />
   </joint>
@@ -996,8 +996,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4203"
-      upper="0.2931"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1798"
       velocity="8.1158" />
   </joint>
@@ -1041,8 +1041,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4804"
-      upper="1.5420"
+      lower="-0.4768"
+      upper="1.5490"
       effort="0.2384"
       velocity="12.863" />
   </joint>
@@ -1086,8 +1086,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4705"
-      upper="1.5709"
+      lower="-0.4683"
+      upper="1.5735"
       effort="0.1866"
       velocity="13.579" />
   </joint>

--- a/urdf/right.urdf
+++ b/urdf/right.urdf
@@ -71,8 +71,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="0.0368"
-      upper="1.6125"
+      lower="0.0475"
+      upper="1.6033"
       effort="0.4452"
       velocity="8.587" />
   </joint>
@@ -116,8 +116,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1576"
-      upper="0.9312"
+      lower="-0.1387"
+      upper="0.9324"
       effort="0.4259"
       velocity="11.1" />
   </joint>
@@ -161,8 +161,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4638"
-      upper="1.5607"
+      lower="-0.4642"
+      upper="1.5623"
       effort="0.1888"
       velocity="12.863" />
   </joint>
@@ -206,8 +206,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4829"
-      upper="1.5451"
+      lower="-0.4699"
+      upper="1.5568"
       effort="0.1468"
       velocity="13.578" />
   </joint>
@@ -291,8 +291,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1611"
-      upper="1.5588"
+      lower="-0.1585"
+      upper="1.5604"
       effort="0.6188"
       velocity="8.203" />
   </joint>
@@ -336,8 +336,8 @@
     <axis
       xyz="0 0.999999999978991 0" />
     <limit
-      lower="-0.4044"
-      upper="0.3054"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1822"
       velocity="8.1158" />
   </joint>
@@ -381,8 +381,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4714"
-      upper="1.5504"
+      lower="-0.4777"
+      upper="1.5485"
       effort="0.2251"
       velocity="12.863" />
   </joint>
@@ -426,7 +426,7 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4644"
+      lower="-0.4683"
       upper="1.5753"
       effort="0.2170"
       velocity="13.578" />
@@ -511,8 +511,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1719"
-      upper="1.5496"
+      lower="-0.1644"
+      upper="1.5516"
       effort="0.6494"
       velocity="8.203" />
   </joint>
@@ -556,8 +556,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4014"
-      upper="0.2996"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1827"
       velocity="8.1158" />
   </joint>
@@ -601,8 +601,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4632"
-      upper="1.5613"
+      lower="-0.4739"
+      upper="1.5512"
       effort="0.2078"
       velocity="12.863" />
   </joint>
@@ -646,8 +646,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4697"
-      upper="1.5702"
+      lower="-0.4684"
+      upper="1.5745"
       effort="0.2018"
       velocity="13.579" />
   </joint>
@@ -731,8 +731,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1601"
-      upper="1.5534"
+      lower="-0.1554"
+      upper="1.5585"
       effort="0.6389"
       velocity="8.203" />
   </joint>
@@ -776,8 +776,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4134"
-      upper="0.3161"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1832"
       velocity="8.1158" />
   </joint>
@@ -821,8 +821,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4782"
-      upper="1.5448"
+      lower="-0.4765"
+      upper="1.5487"
       effort="0.2249"
       velocity="12.863" />
   </joint>
@@ -866,8 +866,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4825"
-      upper="1.5550"
+      lower="-0.4777"
+      upper="1.5634"
       effort="0.2044"
       velocity="13.579" />
   </joint>
@@ -951,8 +951,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1674"
-      upper="1.5539"
+      lower="-0.1626"
+      upper="1.5585"
       effort="0.6441"
       velocity="8.203" />
   </joint>
@@ -996,8 +996,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4203"
-      upper="0.2931"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1798"
       velocity="8.1158" />
   </joint>
@@ -1041,8 +1041,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4804"
-      upper="1.5420"
+      lower="-0.4768"
+      upper="1.5490"
       effort="0.2384"
       velocity="12.863" />
   </joint>
@@ -1086,8 +1086,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4705"
-      upper="1.5709"
+      lower="-0.4683"
+      upper="1.5735"
       effort="0.1866"
       velocity="13.579" />
   </joint>


### PR DESCRIPTION
## Summary

- **MJCF**: add ten named `<site>` elements (`{left,right}_finger{1..5}_tip`) in `mjcf/left.xml` and `mjcf/right.xml`, placed in `group=\"3\"` for IK targets, fingertip pose queries, and touch sensor attachment
- **README**: document the new fingertip sites and show a Python `mujoco` snippet that resolves a site by name and reads its world-frame pose
- **URDF**: unify left/right joint `<limit>` lower/upper bounds using averaged sysid values across `urdf/{left,right,left-ros,right-ros}.urdf`, and restore the four non-thumb MCP2 joints to the standard `-0.37`/`0.37` range to match `v0.2.4` behavior
- **CHANGELOG**: record the additions and fixes under `[Unreleased]`

## Test plan

- [ ] Load `mjcf/left.xml` and `mjcf/right.xml` in `mujoco.viewer`, enable site rendering + Group 3, confirm all ten fingertip sites appear at the correct positions
- [ ] Run the README Python snippet against both hands and verify `site_xpos` / `site_xmat` return sane world-frame values
- [ ] Spot-check `urdf/{left,right,left-ros,right-ros}.urdf` joint limits: non-thumb MCP2 joints are at ±0.37, other joints match averaged sysid values with no left/right asymmetry
- [ ] `ros2 launch wuji_hand_description display.launch.py hand:=left` and `hand:=right` still load cleanly with the new limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为左右手模型的五个手指尖端添加了命名位置点，可用于逆向运动学、姿态查询和触觉传感器关联。
  * 新增文档说明和Python代码示例，展示如何查询手指尖端世界坐标位置和姿态。

* **问题修复**
  * 统一并校正了左右手关节限制范围，提升手部运动的对称性和准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->