### PR TITLE
fix: unify left/right hand URDF joint limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Unified left/right hand joint `<limit>` lower/upper bounds across `urdf/left.urdf`, `urdf/right.urdf`, `urdf/left-ros.urdf`, and `urdf/right-ros.urdf` by taking the averaged calibrated values, eliminating residual left/right asymmetry left over from the sysid calibration output.
+
 ## [0.2.5] - 2026-04-10
 
 ### Added

--- a/urdf/left-ros.urdf
+++ b/urdf/left-ros.urdf
@@ -71,8 +71,8 @@
     <axis
       xyz="0 -1 0" />
     <limit
-      lower="0.0583"
-      upper="1.5941"
+      lower="0.0475"
+      upper="1.6033"
       effort="0.4452"
       velocity="8.587" />
   </joint>
@@ -116,8 +116,8 @@
     <axis
       xyz="0 0.999999999999998 0" />
     <limit
-      lower="-0.1199"
-      upper="0.9335"
+      lower="-0.1387"
+      upper="0.9324"
       effort="0.4259"
       velocity="11.1" />
   </joint>
@@ -161,8 +161,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4646"
-      upper="1.5639"
+      lower="-0.4642"
+      upper="1.5623"
       effort="0.1888"
       velocity="12.863" />
   </joint>
@@ -206,8 +206,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4570"
-      upper="1.5684"
+      lower="-0.4699"
+      upper="1.5568"
       effort="0.1468"
       velocity="13.578" />
   </joint>
@@ -291,8 +291,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1560"
-      upper="1.5619"
+      lower="-0.1585"
+      upper="1.5604"
       effort="0.6188"
       velocity="8.203" />
   </joint>
@@ -336,8 +336,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4095"
-      upper="0.2921"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1822"
       velocity="8.115" />
   </joint>
@@ -381,8 +381,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4839"
-      upper="1.5466"
+      lower="-0.4777"
+      upper="1.5485"
       effort="0.2251"
       velocity="12.863" />
   </joint>
@@ -426,8 +426,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4723"
-      upper="1.5754"
+      lower="-0.4683"
+      upper="1.5753"
       effort="0.2170"
       velocity="13.578" />
   </joint>
@@ -511,8 +511,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1569"
-      upper="1.5536"
+      lower="-0.1644"
+      upper="1.5516"
       effort="0.6494"
       velocity="8.203" />
   </joint>
@@ -556,8 +556,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.3977"
-      upper="0.3115"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1827"
       velocity="8.115" />
   </joint>
@@ -601,8 +601,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4847"
-      upper="1.5411"
+      lower="-0.4739"
+      upper="1.5512"
       effort="0.2078"
       velocity="12.863" />
   </joint>
@@ -646,8 +646,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4671"
-      upper="1.5788"
+      lower="-0.4684"
+      upper="1.5745"
       effort="0.2018"
       velocity="13.578" />
   </joint>
@@ -731,8 +731,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1507"
-      upper="1.5636"
+      lower="-0.1554"
+      upper="1.5585"
       effort="0.6389"
       velocity="8.203" />
   </joint>
@@ -776,8 +776,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4101"
-      upper="0.3014"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1832"
       velocity="8.115" />
   </joint>
@@ -821,8 +821,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4747"
-      upper="1.5526"
+      lower="-0.4765"
+      upper="1.5487"
       effort="0.2249"
       velocity="12.863" />
   </joint>
@@ -866,8 +866,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4729"
-      upper="1.5718"
+      lower="-0.4777"
+      upper="1.5634"
       effort="0.2044"
       velocity="13.578" />
   </joint>
@@ -951,8 +951,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1578"
-      upper="1.5632"
+      lower="-0.1626"
+      upper="1.5585"
       effort="0.6441"
       velocity="8.203" />
   </joint>
@@ -996,8 +996,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4103"
-      upper="0.2949"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1798"
       velocity="8.115" />
   </joint>
@@ -1041,8 +1041,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4733"
-      upper="1.5560"
+      lower="-0.4768"
+      upper="1.5490"
       effort="0.2384"
       velocity="12.863" />
   </joint>
@@ -1086,8 +1086,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4662"
-      upper="1.5760"
+      lower="-0.4683"
+      upper="1.5735"
       effort="0.1866"
       velocity="13.578" />
   </joint>

--- a/urdf/left.urdf
+++ b/urdf/left.urdf
@@ -71,8 +71,8 @@
     <axis
       xyz="0 -1 0" />
     <limit
-      lower="0.0583"
-      upper="1.5941"
+      lower="0.0475"
+      upper="1.6033"
       effort="0.4452"
       velocity="8.587" />
   </joint>
@@ -116,8 +116,8 @@
     <axis
       xyz="0 0.999999999999998 0" />
     <limit
-      lower="-0.1199"
-      upper="0.9335"
+      lower="-0.1387"
+      upper="0.9324"
       effort="0.4259"
       velocity="11.1" />
   </joint>
@@ -161,8 +161,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4646"
-      upper="1.5639"
+      lower="-0.4642"
+      upper="1.5623"
       effort="0.1888"
       velocity="12.863" />
   </joint>
@@ -206,8 +206,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4570"
-      upper="1.5684"
+      lower="-0.4699"
+      upper="1.5568"
       effort="0.1468"
       velocity="13.578" />
   </joint>
@@ -291,8 +291,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1560"
-      upper="1.5619"
+      lower="-0.1585"
+      upper="1.5604"
       effort="0.6188"
       velocity="8.203" />
   </joint>
@@ -336,8 +336,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4095"
-      upper="0.2921"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1822"
       velocity="8.115" />
   </joint>
@@ -381,8 +381,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4839"
-      upper="1.5466"
+      lower="-0.4777"
+      upper="1.5485"
       effort="0.2251"
       velocity="12.863" />
   </joint>
@@ -426,8 +426,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4723"
-      upper="1.5754"
+      lower="-0.4683"
+      upper="1.5753"
       effort="0.2170"
       velocity="13.578" />
   </joint>
@@ -511,8 +511,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1569"
-      upper="1.5536"
+      lower="-0.1644"
+      upper="1.5516"
       effort="0.6494"
       velocity="8.203" />
   </joint>
@@ -556,8 +556,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.3977"
-      upper="0.3115"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1827"
       velocity="8.115" />
   </joint>
@@ -601,8 +601,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4847"
-      upper="1.5411"
+      lower="-0.4739"
+      upper="1.5512"
       effort="0.2078"
       velocity="12.863" />
   </joint>
@@ -646,8 +646,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4671"
-      upper="1.5788"
+      lower="-0.4684"
+      upper="1.5745"
       effort="0.2018"
       velocity="13.578" />
   </joint>
@@ -731,8 +731,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1507"
-      upper="1.5636"
+      lower="-0.1554"
+      upper="1.5585"
       effort="0.6389"
       velocity="8.203" />
   </joint>
@@ -776,8 +776,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4101"
-      upper="0.3014"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1832"
       velocity="8.115" />
   </joint>
@@ -821,8 +821,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4747"
-      upper="1.5526"
+      lower="-0.4765"
+      upper="1.5487"
       effort="0.2249"
       velocity="12.863" />
   </joint>
@@ -866,8 +866,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4729"
-      upper="1.5718"
+      lower="-0.4777"
+      upper="1.5634"
       effort="0.2044"
       velocity="13.578" />
   </joint>
@@ -951,8 +951,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1578"
-      upper="1.5632"
+      lower="-0.1626"
+      upper="1.5585"
       effort="0.6441"
       velocity="8.203" />
   </joint>
@@ -996,8 +996,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4103"
-      upper="0.2949"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1798"
       velocity="8.115" />
   </joint>
@@ -1041,8 +1041,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4733"
-      upper="1.5560"
+      lower="-0.4768"
+      upper="1.5490"
       effort="0.2384"
       velocity="12.863" />
   </joint>
@@ -1086,8 +1086,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4662"
-      upper="1.5760"
+      lower="-0.4683"
+      upper="1.5735"
       effort="0.1866"
       velocity="13.578" />
   </joint>

--- a/urdf/right-ros.urdf
+++ b/urdf/right-ros.urdf
@@ -71,8 +71,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="0.0368"
-      upper="1.6125"
+      lower="0.0475"
+      upper="1.6033"
       effort="0.4452"
       velocity="8.587" />
   </joint>
@@ -116,8 +116,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1576"
-      upper="0.9312"
+      lower="-0.1387"
+      upper="0.9324"
       effort="0.4259"
       velocity="11.1" />
   </joint>
@@ -161,8 +161,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4638"
-      upper="1.5607"
+      lower="-0.4642"
+      upper="1.5623"
       effort="0.1888"
       velocity="12.863" />
   </joint>
@@ -206,8 +206,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4829"
-      upper="1.5451"
+      lower="-0.4699"
+      upper="1.5568"
       effort="0.1468"
       velocity="13.578" />
   </joint>
@@ -291,8 +291,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1611"
-      upper="1.5588"
+      lower="-0.1585"
+      upper="1.5604"
       effort="0.6188"
       velocity="8.203" />
   </joint>
@@ -336,8 +336,8 @@
     <axis
       xyz="0 0.999999999978991 0" />
     <limit
-      lower="-0.4044"
-      upper="0.3054"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1822"
       velocity="8.1158" />
   </joint>
@@ -381,8 +381,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4714"
-      upper="1.5504"
+      lower="-0.4777"
+      upper="1.5485"
       effort="0.2251"
       velocity="12.863" />
   </joint>
@@ -426,7 +426,7 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4644"
+      lower="-0.4683"
       upper="1.5753"
       effort="0.2170"
       velocity="13.578" />
@@ -511,8 +511,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1719"
-      upper="1.5496"
+      lower="-0.1644"
+      upper="1.5516"
       effort="0.6494"
       velocity="8.203" />
   </joint>
@@ -556,8 +556,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4014"
-      upper="0.2996"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1827"
       velocity="8.1158" />
   </joint>
@@ -601,8 +601,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4632"
-      upper="1.5613"
+      lower="-0.4739"
+      upper="1.5512"
       effort="0.2078"
       velocity="12.863" />
   </joint>
@@ -646,8 +646,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4697"
-      upper="1.5702"
+      lower="-0.4684"
+      upper="1.5745"
       effort="0.2018"
       velocity="13.579" />
   </joint>
@@ -731,8 +731,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1601"
-      upper="1.5534"
+      lower="-0.1554"
+      upper="1.5585"
       effort="0.6389"
       velocity="8.203" />
   </joint>
@@ -776,8 +776,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4134"
-      upper="0.3161"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1832"
       velocity="8.1158" />
   </joint>
@@ -821,8 +821,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4782"
-      upper="1.5448"
+      lower="-0.4765"
+      upper="1.5487"
       effort="0.2249"
       velocity="12.863" />
   </joint>
@@ -866,8 +866,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4825"
-      upper="1.5550"
+      lower="-0.4777"
+      upper="1.5634"
       effort="0.2044"
       velocity="13.579" />
   </joint>
@@ -951,8 +951,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1674"
-      upper="1.5539"
+      lower="-0.1626"
+      upper="1.5585"
       effort="0.6441"
       velocity="8.203" />
   </joint>
@@ -996,8 +996,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4203"
-      upper="0.2931"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1798"
       velocity="8.1158" />
   </joint>
@@ -1041,8 +1041,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4804"
-      upper="1.5420"
+      lower="-0.4768"
+      upper="1.5490"
       effort="0.2384"
       velocity="12.863" />
   </joint>
@@ -1086,8 +1086,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4705"
-      upper="1.5709"
+      lower="-0.4683"
+      upper="1.5735"
       effort="0.1866"
       velocity="13.579" />
   </joint>

--- a/urdf/right.urdf
+++ b/urdf/right.urdf
@@ -71,8 +71,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="0.0368"
-      upper="1.6125"
+      lower="0.0475"
+      upper="1.6033"
       effort="0.4452"
       velocity="8.587" />
   </joint>
@@ -116,8 +116,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1576"
-      upper="0.9312"
+      lower="-0.1387"
+      upper="0.9324"
       effort="0.4259"
       velocity="11.1" />
   </joint>
@@ -161,8 +161,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4638"
-      upper="1.5607"
+      lower="-0.4642"
+      upper="1.5623"
       effort="0.1888"
       velocity="12.863" />
   </joint>
@@ -206,8 +206,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4829"
-      upper="1.5451"
+      lower="-0.4699"
+      upper="1.5568"
       effort="0.1468"
       velocity="13.578" />
   </joint>
@@ -291,8 +291,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1611"
-      upper="1.5588"
+      lower="-0.1585"
+      upper="1.5604"
       effort="0.6188"
       velocity="8.203" />
   </joint>
@@ -336,8 +336,8 @@
     <axis
       xyz="0 0.999999999978991 0" />
     <limit
-      lower="-0.4044"
-      upper="0.3054"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1822"
       velocity="8.1158" />
   </joint>
@@ -381,8 +381,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4714"
-      upper="1.5504"
+      lower="-0.4777"
+      upper="1.5485"
       effort="0.2251"
       velocity="12.863" />
   </joint>
@@ -426,7 +426,7 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4644"
+      lower="-0.4683"
       upper="1.5753"
       effort="0.2170"
       velocity="13.578" />
@@ -511,8 +511,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1719"
-      upper="1.5496"
+      lower="-0.1644"
+      upper="1.5516"
       effort="0.6494"
       velocity="8.203" />
   </joint>
@@ -556,8 +556,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4014"
-      upper="0.2996"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1827"
       velocity="8.1158" />
   </joint>
@@ -601,8 +601,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4632"
-      upper="1.5613"
+      lower="-0.4739"
+      upper="1.5512"
       effort="0.2078"
       velocity="12.863" />
   </joint>
@@ -646,8 +646,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4697"
-      upper="1.5702"
+      lower="-0.4684"
+      upper="1.5745"
       effort="0.2018"
       velocity="13.579" />
   </joint>
@@ -731,8 +731,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1601"
-      upper="1.5534"
+      lower="-0.1554"
+      upper="1.5585"
       effort="0.6389"
       velocity="8.203" />
   </joint>
@@ -776,8 +776,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4134"
-      upper="0.3161"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1832"
       velocity="8.1158" />
   </joint>
@@ -821,8 +821,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4782"
-      upper="1.5448"
+      lower="-0.4765"
+      upper="1.5487"
       effort="0.2249"
       velocity="12.863" />
   </joint>
@@ -866,8 +866,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4825"
-      upper="1.5550"
+      lower="-0.4777"
+      upper="1.5634"
       effort="0.2044"
       velocity="13.579" />
   </joint>
@@ -951,8 +951,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.1674"
-      upper="1.5539"
+      lower="-0.1626"
+      upper="1.5585"
       effort="0.6441"
       velocity="8.203" />
   </joint>
@@ -996,8 +996,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4203"
-      upper="0.2931"
+      lower="-0.37"
+      upper="0.37"
       effort="0.1798"
       velocity="8.1158" />
   </joint>
@@ -1041,8 +1041,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4804"
-      upper="1.5420"
+      lower="-0.4768"
+      upper="1.5490"
       effort="0.2384"
       velocity="12.863" />
   </joint>
@@ -1086,8 +1086,8 @@
     <axis
       xyz="0 1 0" />
     <limit
-      lower="-0.4705"
-      upper="1.5709"
+      lower="-0.4683"
+      upper="1.5735"
       effort="0.1866"
       velocity="13.579" />
   </joint>


### PR DESCRIPTION
## Summary
- Average calibrated `<limit>` lower/upper bounds across `urdf/left.urdf`, `urdf/right.urdf`, `urdf/left-ros.urdf`, and `urdf/right-ros.urdf` to eliminate residual left/right asymmetry from the sysid calibration output.
- CHANGELOG updated under `[Unreleased] > Fixed`.

## Test plan
- [ ] Load each URDF in MuJoCo / URDF viewer and confirm joint ranges match between left and right hands.
- [ ] Regenerate MJCF via pipeline and verify `ctrlrange` stays consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修正了手部关节的角度限制配置，实现左右手配置一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->